### PR TITLE
Bump Java version to 1.8 as required by OkHttp 3.13+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.android.application'
 
 android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.andit.alexandrespitz.bugdex"


### PR DESCRIPTION
Comme annoncé ici : https://medium.com/square-corner-blog/okhttp-3-13-requires-android-5-818bb78d07ce , OkHTTP 3.13+ nécessite Java 8 (et Android 5+).  
On met donc à jour la version de Java dans le build.gradle de l'app.  
Bug reproduit sur émulateur 8.0 et corrigé avec cette modif.

Bon weekend :)